### PR TITLE
Fix bugzilla trello integration

### DIFF
--- a/bugzilla_trello_integration.meta.js
+++ b/bugzilla_trello_integration.meta.js
@@ -1,5 +1,5 @@
 // ==UserScript==
 // @name         Bugzilla Trello integration
 // @namespace    https://blog.ladslezak.cz/
-// @version      0.1.5
+// @version      0.1.6
 // ==/UserScript==

--- a/bugzilla_trello_integration.user.js
+++ b/bugzilla_trello_integration.user.js
@@ -155,8 +155,8 @@
             responseType: "JSON",
             url: buildTrelloUrl("cards", card),
             onload: function(response) {
+                var ret = response.responseText
                 // debug(response);
-                var ret = JSON.parse(response.responseText);
                 debug(ret);
 
                 if (response.status != 200) {
@@ -491,7 +491,7 @@
         url: buildTrelloUrl(path, params),
         onload: function(response) {
           debug(response);
-          var ret = JSON.parse(response.responseText);
+          var ret = response.responseText;
           debug(ret);
         }
       });
@@ -506,7 +506,7 @@
           onload: function(response) {
             debug(response);
             // TODO: error handling
-            resolve(JSON.parse(response.responseText));
+            resolve(response.responseText);
           },
           onerror: function() {
             reject();
@@ -585,7 +585,7 @@
         }),
         onload: function(response) {
             // debug(response);
-            var ret = JSON.parse(response.responseText);
+            var ret = response.responseText;
             debug(ret);
 
             // filter the card name matches only, Trello searches in descriptions as well

--- a/bugzilla_trello_integration.user.js
+++ b/bugzilla_trello_integration.user.js
@@ -155,7 +155,7 @@
             responseType: "JSON",
             url: buildTrelloUrl("cards", card),
             onload: function(response) {
-                var ret = response.responseText
+                var ret = response.response
                 // debug(response);
                 debug(ret);
 
@@ -318,7 +318,7 @@
                 if (response.status == 401) {
                   setTrelloContent("<a href='https://trello.com/login'>Log into Trello</a>");
                 } else if (response.status == 200) {
-                    var api_key = apiKeyFromHtml(response.responseText);
+                    var api_key = apiKeyFromHtml(response.response);
                     // debug(api_key);
                     if (api_key) {
                         // save the key for later
@@ -491,7 +491,7 @@
         url: buildTrelloUrl(path, params),
         onload: function(response) {
           debug(response);
-          var ret = response.responseText;
+          var ret = response.response;
           debug(ret);
         }
       });
@@ -506,7 +506,7 @@
           onload: function(response) {
             debug(response);
             // TODO: error handling
-            resolve(response.responseText);
+            resolve(response.response);
           },
           onerror: function() {
             reject();
@@ -585,7 +585,7 @@
         }),
         onload: function(response) {
             // debug(response);
-            var ret = response.responseText;
+            var ret = response.response;
             debug(ret);
 
             // filter the card name matches only, Trello searches in descriptions as well

--- a/bugzilla_trello_integration.user.js
+++ b/bugzilla_trello_integration.user.js
@@ -154,12 +154,12 @@
             method: "POST",
             responseType: "JSON",
             url: buildTrelloUrl("cards", card),
-            onload: function(response) {
-                var ret = response.response
-                // debug(response);
+            onload: function(xhr) {
+                var ret = xhr.response
+                // debug(xhr);
                 debug(ret);
 
-                if (response.status != 200) {
+                if (xhr.status != 200) {
                     console.error("Error: Creating the card failed!");
                     displayError();
                     return;
@@ -312,13 +312,13 @@
         GM_xmlhttpRequest({
             method: "GET",
             url: "https://trello.com/app-key",
-            onload: function(response) {
+            onload: function(xhr) {
                 hideTrelloSpinner();
-                // debug(response);
-                if (response.status == 401) {
+                // debug(xhr);
+                if (xhr.status == 401) {
                   setTrelloContent("<a href='https://trello.com/login'>Log into Trello</a>");
-                } else if (response.status == 200) {
-                    var api_key = apiKeyFromHtml(response.response);
+                } else if (xhr.status == 200) {
+                    var api_key = apiKeyFromHtml(xhr.response);
                     // debug(api_key);
                     if (api_key) {
                         // save the key for later
@@ -326,11 +326,11 @@
                         // display the authorization link
                         displayTrelloAuthorization();
                     } else {
-                        console.error(response);
+                        console.error(xhr);
                         displayError();
                     }
                 } else {
-                    console.error(response);
+                    console.error(xhr);
                     displayError();
                 }
             }
@@ -489,9 +489,9 @@
         method: "GET",
         responseType: "JSON",
         url: buildTrelloUrl(path, params),
-        onload: function(response) {
-          debug(response);
-          var ret = response.response;
+        onload: function(xhr) {
+          debug(xhr);
+          var ret = xhr.response;
           debug(ret);
         }
       });
@@ -503,10 +503,10 @@
           method: method,
           responseType: "JSON",
           url: buildTrelloUrl(path, params),
-          onload: function(response) {
-            debug(response);
+          onload: function(xhr) {
+            debug(xhr);
             // TODO: error handling
-            resolve(response.response);
+            resolve(xhr.response);
           },
           onerror: function() {
             reject();
@@ -583,9 +583,9 @@
           card_board: true,
           board_fields: "name"
         }),
-        onload: function(response) {
-            // debug(response);
-            var ret = response.response;
+        onload: function(xhr) {
+            // debug(xhr);
+            var ret = xhr.response;
             debug(ret);
 
             // filter the card name matches only, Trello searches in descriptions as well

--- a/bugzilla_trello_integration.user.js
+++ b/bugzilla_trello_integration.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Bugzilla Trello integration
 // @namespace    https://blog.ladslezak.cz/
-// @version      0.1.5
+// @version      0.1.6
 // @description  Integrate Bugzilla with Trello
 // @author       Ladislav Slezák
 // @match        https://bugzilla.suse.com/show_bug.cgi*


### PR DESCRIPTION
Recent versions of Firefox browser do not honor the `xhr.responseText` property, which is being parsed in advance using the given `xhr.responseType`.

As agreed in https://github.com/lslezak/monkey_scripts/pull/4#issuecomment-795402632, using `xhr.response` property looks a good solution that should work in both, Firefox and Webkit browsers.


<details>
  <summary>Show/hide Firefox complain</summary>

```js
Uncaught SyntaxError: JSON.parse: unexpected character at line 1 column 2 of the JSON data
    onload moz-extension://userscripts/Bugzilla Trello integration.user.js:590
    s eval:4
    i eval line 2 > Function:36
    s eval:4
    i eval line 2 > Function:13
    s eval line 2 > Function:13
    v eval:13
    v eval:13
    s eval:4
    t eval:12
    s eval:4
    h eval:12
    h eval:12
    send eval:13
    s eval line 2 > Function:13
    setTimeout eval line 2 > Function:14
    i eval line 2 > Function:36
    xmlhttpRequest eval line 2 > Function:43
    message eval line 2 > Function:19
    s eval:4
    t eval:3
    message eval line 2 > Function:19
    message eval line 2 > Function:19
    anonymous eval line 2 > Function:77
    v eval:13
eval line 4 > eval:590:28
```

</details> 

## Manual tests:

- [x] Retrieving the current card
- [ ] Creating a new card
